### PR TITLE
Рефакторинг блока comment

### DIFF
--- a/desktop.blocks/comment/__edit/comment__edit.bemhtml
+++ b/desktop.blocks/comment/__edit/comment__edit.bemhtml
@@ -2,8 +2,9 @@ block('comment').elem('edit')(
     def()(function() {
         return applyCtx({
             block: 'link',
-            url: '#',
             title: 'Редактировать ответ',
+            mods: { pseudo: true },
+            js: { action: 'edit' },
             content: {
                 block: 'icon',
                 mods: { action: 'edit', size: '16', hover: 'opacity' }

--- a/desktop.blocks/comment/__edit/comment__edit.bemhtml
+++ b/desktop.blocks/comment/__edit/comment__edit.bemhtml
@@ -4,7 +4,7 @@ block('comment').elem('edit')(
             block: 'link',
             title: 'Редактировать ответ',
             mods: { pseudo: true },
-            js: { action: 'edit' },
+            js: { action: 'Edit' },
             content: {
                 block: 'icon',
                 mods: { action: 'edit', size: '16', hover: 'opacity' }

--- a/desktop.blocks/comment/__edit/comment__edit.deps.yaml
+++ b/desktop.blocks/comment/__edit/comment__edit.deps.yaml
@@ -2,5 +2,6 @@
   mods: { action: edit, hover: opacity, size: 16 }
 
 - block: link
+  mods: { pseudo: true }
 
 - elems: [edit-form]

--- a/desktop.blocks/comment/__edit/comment__edit.roo
+++ b/desktop.blocks/comment/__edit/comment__edit.roo
@@ -1,4 +1,9 @@
 .comment__edit
 {
     margin-left: 10px;
+
+    &:focus
+    {
+        outline: none;
+    }
 }

--- a/desktop.blocks/comment/__remove/comment__remove.bemhtml
+++ b/desktop.blocks/comment/__remove/comment__remove.bemhtml
@@ -2,8 +2,9 @@ block('comment').elem('remove')(
     def()(function() {
         return applyCtx({
             block: 'link',
-            url: '#',
             title: 'Удалить ответ',
+            mods: { pseudo: true },
+            js: { action: 'remove' },
             content: {
                 block: 'icon',
                 mods: { action: 'remove', size: '16', hover: 'opacity' }

--- a/desktop.blocks/comment/__remove/comment__remove.bemhtml
+++ b/desktop.blocks/comment/__remove/comment__remove.bemhtml
@@ -4,7 +4,7 @@ block('comment').elem('remove')(
             block: 'link',
             title: 'Удалить ответ',
             mods: { pseudo: true },
-            js: { action: 'remove' },
+            js: { action: 'Remove' },
             content: {
                 block: 'icon',
                 mods: { action: 'remove', size: '16', hover: 'opacity' }

--- a/desktop.blocks/comment/__remove/comment__remove.deps.yaml
+++ b/desktop.blocks/comment/__remove/comment__remove.deps.yaml
@@ -2,3 +2,4 @@
   mods: { action: remove, hover: opacity, size: 16 }
 
 - block: link
+  mods: { pseudo: true }

--- a/desktop.blocks/comment/__remove/comment__remove.roo
+++ b/desktop.blocks/comment/__remove/comment__remove.roo
@@ -1,4 +1,10 @@
 .comment__remove
 {
     margin-left: 10px;
+
+    &:focus
+    {
+        outline: none;
+    }
 }
+

--- a/desktop.blocks/comment/comment.js
+++ b/desktop.blocks/comment/comment.js
@@ -1,18 +1,17 @@
 modules.define('comment', ['i-bem__dom', 'jquery'], function(provide, BEMDOM, $) {
     provide(BEMDOM.decl(this.name, {
 
+        /**
+         * Обработчик на сабмит формы редактирования
+         * @param e
+         * @param data
+         * @returns {boolean}
+         * @private
+         */
         _onSubmitEdit: function(e, data) {
+            if(this._getFormEdit().isEmptyInput('body')) return false;
 
-            if(this._formEdit.isEmptyInput('body')) {
-                return false;
-            }
-
-            var _this = this;
-
-            this._spin = this.findBlockInside('spin');
-            this._button =  this.findBlockInside(this.elem('edit-button'), 'button');
-
-            this._beforeEdit();
+            this._submitProgress(true);
 
             data.push({ name: 'id', value: this.params.id });
 
@@ -20,88 +19,153 @@ modules.define('comment', ['i-bem__dom', 'jquery'], function(provide, BEMDOM, $)
                 dataType: 'html',
                 type: 'PUT',
                 data: data,
-                url: this.params.forumUrl + 'issues/' + this.params.issueNumber + '/comments/' + this.params.id + '/?__mode=content'
+                url: this.params.forumUrl + 'issues/' + this.params.issueNumber + '/comments/' + this.params.id + '/?__mode=content',
+                context: this
             }).done(function(html) {
-                _this._render(html, 'update');
+                BEMDOM.update(this.domElem, html);
 
-                _this._afterEdit();
+                this._dropCached();
+                this._submitProgress(false);
             });
         },
 
-        _beforeEdit: function() {
-            this._spin.setMod('progress', true);
-            this._button.setMod('disabled', true);
+        /**
+         * Кешируем инстанс формы редактирования
+         */
+        _formEdit: null,
+
+        /**
+         * Возвращает инстанс формы редактирования
+         * @returns {BEMDOM}
+         * @private
+         */
+        _getFormEdit: function() {
+            return this._formEdit || (this._formEdit = this.findBlockInside('edit-form', 'forum-form'));
         },
 
-        _afterEdit: function() {
-            this._toggleFormEdit();
+        /**
+         * Кешируем инстанс кнопки отмены
+         */
+        _cancelButton: null,
 
-            this._spin.delMod('progress');
-            this._button.delMod('disabled');
+        /**
+         * Возвращает инстанс инопки отмены
+         * @returns {BEMDOM}
+         * @private
+         */
+        _getCancelButton: function() {
+            return this._cancelButton || (this._cancelButton = this.findBlockInside('edit-cancel', 'button'));
         },
 
-        _render: function(html, type) {
-            BEMDOM[type](this.domElem, html);
+        /**
+         * Кешируем инстанс кнопки редактирования
+         */
+        _editButton: null,
+
+        /**
+         * Возвращает инстанс кнопки редактирования
+         * @returns {BEMDOM}
+         * @private
+         */
+        _getEditButton: function() {
+            return this._editButton || (this._editButton = this.findBlockInside('edit-button', 'button'));
         },
 
+        /**
+         * Сбрасываем закешированные инстансы после обновления контента
+         * @private
+         */
+        _dropCached: function() {
+            this._formEdit = null;
+            this._editButton = null;
+            this._cancelButton = null;
+        },
+
+        /**
+         * Прогресс сохранения отредактированного комментария
+         * @param progress
+         * @private
+         */
+        _submitProgress: function(progress) {
+            var spin = this.findBlockInside('spin'),
+                button =  this._getEditButton();
+
+            spin.setMod('progress', progress);
+            button.setMod('disabled', progress);
+        },
+
+        /**
+         * Показываем / скрываем форму редактирования
+         * @private
+         */
         _toggleFormEdit: function() {
-            var body = this.findElem('body');
+            var body = this.findElem('body'),
+                formEdit = this._getFormEdit();
 
-            this._formEdit.toggleMod('visibility', 'hidden', '');
-            this.toggleMod(body, 'visibility', 'hidden', '', !this._formEdit.hasMod('visibility', 'hidden'));
+            formEdit.toggleMod('visibility', 'hidden', '');
+            this.toggleMod(body, 'visibility', 'hidden', '', !formEdit.hasMod('visibility', 'hidden'));
         },
 
-        _onClickEditCancel: function(e) {
-            e.preventDefault();
-
+        /**
+         * Обработчик клика по кнопке отмены редактирования
+         * @param e
+         * @private
+         */
+        _onClickEditCancel: function() {
             this._toggleFormEdit();
+            this._getFormEdit().un('submit', this._onSubmitEdit, this);
         },
 
+        /**
+         * Задаем высоту формы редактирования
+         * @private
+         */
         _setFormEditHeight: function() {
             var height = this.findElem('body').outerHeight();
 
             this.findElem('edit-textarea').height(height);
         },
 
+        /**
+         * Обработчик клика по иконке редактирования
+         * @private
+         */
         _onClickEdit: function() {
-            this._formEdit = this.findBlockInside(this.findElem('edit-form'), 'forum-form');
-
             this._setFormEditHeight();
-
             this._toggleFormEdit();
 
-            this._formEdit.on('submit', this._onSubmitEdit, this);
-
-            this._buttonCancel = this.findBlockInside(this.findElem('edit-cancel'), 'button');
-            this._buttonCancel.on('click', this._onClickEditCancel, this);
+            this._getFormEdit().on('submit', this._onSubmitEdit, this);
+            this._getCancelButton().on('click', this._onClickEditCancel, this);
         },
 
+        /**
+         * Обработчик клика по иконке удаления
+         * @private
+         */
         _onClickRemove: function() {
-            var _this = this;
-
             if(window.confirm('Вы уверены?')) {
                 $.ajax({
                     type: 'DELETE',
-                    url: this.params.forumUrl + 'issues/' + this.params.issueNumber + '/comments/' + this.params.id + '/'
+                    url: this.params.forumUrl + 'issues/' + this.params.issueNumber + '/comments/' + this.params.id + '/',
+                    context: this
                 }).done(function() {
-                    _this.emit('comment:delete');
+                    this.emit('comment:delete');
 
-                    BEMDOM.destruct(_this.domElem);
+                    BEMDOM.destruct(this.domElem);
                 });
             }
         }
     }, {
         live: function() {
-            this.liveBindTo('remove', 'click', function(e) {
-                e.preventDefault();
+            this.liveInitOnBlockInsideEvent('click', 'link', function(e) {
+                // проверяем куда ткнули и выбираем действие
+                var action = e.target.params.action;
 
-                this._onClickRemove();
-            });
-
-            this.liveBindTo('edit', 'click', function(e) {
-                e.preventDefault();
-
-                this._onClickEdit();
+                if(action === 'edit') {
+                    this._onClickEdit();
+                } else if(action === 'remove') {
+                    this._onClickRemove();
+                }
             });
         }
     }));

--- a/desktop.blocks/comment/comment.js
+++ b/desktop.blocks/comment/comment.js
@@ -157,14 +157,8 @@ modules.define('comment', ['i-bem__dom', 'jquery'], function(provide, BEMDOM, $)
     }, {
         live: function() {
             this.liveInitOnBlockInsideEvent('click', 'link', function(e) {
-                // проверяем куда ткнули и выбираем действие
-                var action = e.target.params.action;
-
-                if(action === 'edit') {
-                    this._onClickEdit();
-                } else if(action === 'remove') {
-                    this._onClickRemove();
-                }
+                // Задаем необходимый обработчик для клика по кнопкам Удалить/редактировать
+                this['_onClick' + e.target.params.action]();
             });
         }
     }));

--- a/desktop.blocks/comment/comment.js
+++ b/desktop.blocks/comment/comment.js
@@ -108,7 +108,6 @@ modules.define('comment', ['i-bem__dom', 'jquery'], function(provide, BEMDOM, $)
 
         /**
          * Обработчик клика по кнопке отмены редактирования
-         * @param e
          * @private
          */
         _onClickEditCancel: function() {


### PR DESCRIPTION
Рефакторинг блока comment:
- Для редактирования / удаления используем link_pseudo
- Переделанный live-init (слушаем не DOM, но bem события)
- Убрал _this, для $.ajax достаточно передавать context
- Единый метод для спиннера (принимает булевое как старт/стоп)
- Кэширование формы и двух кнопок (редактировать и отмена) + сброс кэша после обновления контента
- Комментарии для JS
